### PR TITLE
Add clone iOSPrivateProjectInfo repo step

### DIFF
--- a/travis/build.sh
+++ b/travis/build.sh
@@ -5,7 +5,9 @@ set -ex
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     echo "Testings is disabled due to to issue BRIDGE-1727"
     # bundle exec fastlane test scheme:"Smart4SURE"
-elif [ "$TRAVIS_BRANCH" = "master" ]; then
+fi
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    git clone https://github.com/Sage-Bionetworks/iOSPrivateProjectInfo.git ../iOSPrivateProjectInfo
     bundle exec fastlane ci_archive scheme:"Smart4SURE" export_method:"enterprise"
 fi
 exit $?


### PR DESCRIPTION
Smart4SURE requires iOSPrivateProjectInfo repo to run archive build
so we clone it before running the build.