### PR TITLE
increase build timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 - bundle update
 - echo -e "machine github.com\n  login $CI_USER_TOKEN" >> ~/.netrc
 script:
-- "travis_wait 30 ./travis/build.sh"
+- "travis_wait 45 ./travis/build.sh"
 deploy:
   skip_cleanup: true
   provider: s3


### PR DESCRIPTION
Builds on Travis is super slow and occasionally timeout so we need to increase the timeout.  